### PR TITLE
fix: 운영 서버 8080 포트 할당

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
         dialect: org.hibernate.dialect.MariaDBDialect
 
 server:
-  port: 80
+  port: 8080
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
80 포트 사용하려면 추가적인 설정이 필요한데 이후에 https 도입하기 전까지만 임시로 사용할 포트라 편의를 위해 8080 사용